### PR TITLE
fix "X/Y Scatter chart color column field not working with string typed columns" 

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -66,10 +66,8 @@ function xyScatter(container, settings) {
             if (hasSplitBy) {
                 color = seriesColorsFromDistinct(settings, data);
                 // TODO: Legend should have cartesian product labels (ColorBy|SplitBy)
-                legend = symbolLegend()
-                    .settings(settings)
-                    .scale(symbols)
-                    .color(color);
+                // For now, just use monocolor legends.
+                legend = symbolLegend().settings(settings).scale(symbols);
             } else {
                 color = seriesColorsFromField(settings, colorByField);
                 legend = colorLegend().settings(settings).scale(color);
@@ -80,7 +78,7 @@ function xyScatter(container, settings) {
         }
     } else {
         color = seriesColorsFromGroups(settings);
-        legend = symbolLegend().settings(settings).scale(symbols).color(color);
+        legend = symbolLegend().settings(settings).scale(symbols);
     }
 
     const size = settings.realValues[3]

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -36,7 +36,9 @@ export function pointSeriesCanvas(
     }
 
     series.decorate((context, d) => {
-        let colorValue = color(d.colorValue);
+        const colorValue = color(
+            d.colorValue !== undefined ? d.colorValue : seriesKey
+        );
 
         const opacity = settings.colorStyles && settings.colorStyles.opacity;
         if (label) {

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -36,7 +36,7 @@ export function pointSeriesCanvas(
     }
 
     series.decorate((context, d) => {
-        let colorValue = color(d.colorValue);
+        const colorValue = d.colorValue;
 
         const opacity = settings.colorStyles && settings.colorStyles.opacity;
         if (label) {

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -22,8 +22,7 @@ export function pointSeriesCanvas(
     color,
     label,
     symbols,
-    scale_factor = 1,
-    
+    scale_factor = 1
 ) {
     let series = seriesCanvasPoint()
         .crossValue((d) => d.x)

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -23,7 +23,7 @@ export function pointSeriesCanvas(
     label,
     symbols,
     scale_factor = 1,
-    useSeriesKey = False
+    
 ) {
     let series = seriesCanvasPoint()
         .crossValue((d) => d.x)
@@ -37,7 +37,7 @@ export function pointSeriesCanvas(
     }
 
     series.decorate((context, d) => {
-        let colorValue = useSeriesKey ? color(seriesKey) : color(d.colorValue);
+        let colorValue = color(d.colorValue);
 
         const opacity = settings.colorStyles && settings.colorStyles.opacity;
         if (label) {

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -16,6 +16,9 @@ export function seriesColors(settings) {
     return colorScale().settings(settings).domain(domain)();
 }
 
+// TODO: We're iterating over all the data here to get the unique values for each colorBy field.
+// This is the only way to do it since we don't know the range of these values ahead of time.
+// This should be WASM-side code.
 export function seriesColorsFromField(settings, field) {
     const data = settings.data;
     const key = settings.realValues[field];
@@ -111,7 +114,7 @@ export function withOpacity(color, opacity = 0.5) {
 export function setOpacity(opacity) {
     return (color) => {
         const decoded = d3.color(color);
-        if (decoded != null) {
+        if (decoded !== null && decoded !== undefined) {
             decoded.opacity = opacity;
         }
         return decoded + "";

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -16,6 +16,18 @@ export function seriesColors(settings) {
     return colorScale().settings(settings).domain(domain)();
 }
 
+export function seriesColorsFromField(settings, field) {
+    const data = settings.data;
+    const key = settings.realValues[field];
+    const domain = data
+        .map((obj) => obj[key])
+        .reduce((accum, val) => {
+            if (!accum.includes(val)) accum.push(val);
+            return accum;
+        }, []);
+    return colorScale().settings(settings).domain(domain)();
+}
+
 export function seriesColorsFromDistinct(settings, data) {
     let domain = Array.from(new Set(data));
     return colorScale().settings(settings).domain(domain)();


### PR DESCRIPTION
Hi @zxy994, thank you for the updates!

After talking with @texodus I decided to take a look at this PR. We also realized that there are quite a few changes to how legends work that we need to make on the WASM side. In the meantime, I have some changes I'd like to merge into your branch.

First, I refactored some of the legend-determining code to be more readable. 

The biggest change though is your solution to matching the chart color to the legend color. Although your solution works in the case where we have a splitBy and colorByString, I found it didn't work for some other cases. Also, data coloring usually happens before making it to `pointSeriesCanvas()`, so we wanted to make it consistent.

In the case where we have splitBy and colorByString, we need a key which combines the values for colorBy and splitBy. For an example, try splitting by two values. However, combining the colorBy and splitBy values requires iterating over the entire dataset, which is something we definitely don't want to do in rendering code. For now, we decided to leave the legend with a single color, and use it only to indicate the splitBy shape. This issue, and others concerning the legends, will be tackled in an issue (https://github.com/finos/perspective/issues/2298).

I created `seriesColorFromField()` to tackle the case where we were not splitting, but still needed to color by the unique values of the colorBy string field. This should hopefully be refactored when we move the iteration WASM-side.

@zxy994, please take a look at these changes and let me know what you think.